### PR TITLE
feat: add core Supabase entities with RLS/RPC and typed service access

### DIFF
--- a/lib/services/quiz.service.ts
+++ b/lib/services/quiz.service.ts
@@ -10,6 +10,8 @@
 
 import { createClientWithAnonJwt } from '@/utils/supabase/client-with-anon-jwt';
 import { getAnonToken } from './anon-jwt.service';
+import { mapSupabaseError } from './supabase-error';
+import type { TableRow, TableUpdate } from '@/lib/supabase/types';
 
 // --- Types ---
 
@@ -28,20 +30,7 @@ export interface DeviceInfo {
   userAgent: string;
 }
 
-export interface QuizSessionData {
-  id: string;
-  session_id: string;
-  anonymous_user_id: string;
-  total_questions: number;
-  completed_questions: number;
-  correct_answers: number;
-  device_type: string;
-  user_agent: string;
-  is_completed: boolean;
-  created_at: string;
-  expires_at: string;
-  total_summary_score: number;
-}
+export type QuizSessionData = TableRow<'quiz_sessions'>;
 
 export interface SessionCreateOptions {
   totalQuestions: number;
@@ -154,7 +143,7 @@ export class QuizService {
 
       const { data, error } = await supabase
         .from('quiz_sessions')
-        .update(updateData)
+        .update(updateData as TableUpdate<'quiz_sessions'>)
         .eq('session_id', sessionId)
         .select()
         .single();
@@ -170,7 +159,7 @@ export class QuizService {
       console.error('[QuizService] Update session error:', error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Failed to update session'
+        error: mapSupabaseError(error as Error, 'Failed to update session').message
       };
     }
   }

--- a/lib/services/session.service.ts
+++ b/lib/services/session.service.ts
@@ -7,24 +7,10 @@
 
 import { createClient } from '@/utils/supabase/client';
 import { getOrCreateAnonymousUser } from './anonymous-user.service';
+import { mapSupabaseError } from './supabase-error';
+import type { TableInsert, TableRow, TableUpdate } from '@/lib/supabase/types';
 
-export interface QuizSessionData {
-  id: string;
-  session_id: string;
-  anonymous_user_id: string;
-  total_questions: number;
-  completed_questions: number;
-  correct_answers: number;
-  device_type: string;
-  user_agent: string;
-  screen_resolution: string;
-  browser_info: string;
-  is_completed: boolean;
-  created_at: string;
-  expires_at: string;
-  completion_time_ms?: number;
-  total_summary_score: number;
-}
+export type QuizSessionData = TableRow<'quiz_sessions'>;
 
 export interface SessionCreateOptions {
   totalQuestions: number;
@@ -76,7 +62,7 @@ export const createQuizSession = async (
       ? anonymousUser.id
       : `user_${anonymousUser.id}`;
     
-    const sessionData = {
+    const sessionData: TableInsert<'quiz_sessions'> = {
       session_id: sessionId,
       anonymous_user_id: ensuredAnonymousId,
       total_questions: options.totalQuestions,
@@ -101,7 +87,7 @@ export const createQuizSession = async (
       console.error('[SessionService] Failed to create session:', error);
       return {
         success: false,
-        error: `Failed to create session: ${error.message}`
+        error: mapSupabaseError(error, "Failed to create session").message
       };
     }
 
@@ -140,7 +126,7 @@ export const updateQuizSession = async (
       console.error('[SessionService] Failed to update session:', error);
       return {
         success: false,
-        error: `Failed to update session: ${error.message}`
+        error: mapSupabaseError(error, "Failed to update session").message
       };
     }
 
@@ -171,7 +157,7 @@ export const completeQuizSession = async (
   try {
     const supabase = createClient();
 
-    const updateData: SessionUpdateData = {
+    const updateData: TableUpdate<'quiz_sessions'> = {
       ...completionData,
       is_completed: true
     };
@@ -187,7 +173,7 @@ export const completeQuizSession = async (
       console.error('[SessionService] Failed to complete session:', error);
       return {
         success: false,
-        error: `Failed to complete session: ${error.message}`
+        error: mapSupabaseError(error, "Failed to complete session").message
       };
     }
 
@@ -221,16 +207,10 @@ export const getQuizSession = async (
       .single();
 
     if (error) {
-      if (error.code === 'PGRST116') {
-        return {
-          success: false,
-          error: 'Session not found'
-        };
-      }
-      console.error('[SessionService] Failed to get session:', error);
+      const mapped = mapSupabaseError(error, "Failed to get session");
       return {
         success: false,
-        error: `Failed to get session: ${error.message}`
+        error: mapped.message
       };
     }
 

--- a/lib/services/supabase-error.ts
+++ b/lib/services/supabase-error.ts
@@ -1,0 +1,17 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+
+export class ServiceError extends Error {
+  constructor(message: string, readonly code = 'UNKNOWN') {
+    super(message);
+    this.name = 'ServiceError';
+  }
+}
+
+export const mapSupabaseError = (error: PostgrestError | Error | null, fallback: string): ServiceError => {
+  if (!error) return new ServiceError(fallback);
+  if ('code' in error && typeof error.code === 'string') {
+    if (error.code === 'PGRST116') return new ServiceError('Resource not found', error.code);
+    return new ServiceError(error.message || fallback, error.code);
+  }
+  return new ServiceError(error.message || fallback);
+};

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -1,0 +1,11 @@
+import type { Database as GeneratedDatabase } from '@/lib/database.types';
+
+export type Database = GeneratedDatabase;
+
+export type PublicSchema = Database['public'];
+export type PublicTables = PublicSchema['Tables'];
+export type PublicTableName = keyof PublicTables;
+
+export type TableRow<T extends PublicTableName> = PublicTables[T]['Row'];
+export type TableInsert<T extends PublicTableName> = PublicTables[T]['Insert'];
+export type TableUpdate<T extends PublicTableName> = PublicTables[T]['Update'];

--- a/supabase/migrations/07-core-entities-rls-and-rpc.sql
+++ b/supabase/migrations/07-core-entities-rls-and-rpc.sql
@@ -1,0 +1,141 @@
+-- Core entities, indexes, RLS policies, and dashboard RPCs
+
+create table if not exists public.user_profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  display_name text,
+  role text not null default 'user' check (role in ('user','admin','service')),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.quiz_content (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  title text not null,
+  status text not null default 'draft' check (status in ('draft','published','archived')),
+  content jsonb not null default '{}'::jsonb,
+  created_by uuid not null references auth.users(id),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.quiz_attempts (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  quiz_id uuid not null references public.quiz_content(id) on delete cascade,
+  status text not null default 'started' check (status in ('started','completed','abandoned')),
+  score numeric(5,2),
+  started_at timestamptz not null default now(),
+  completed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.user_events (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  attempt_id uuid references public.quiz_attempts(id) on delete set null,
+  event_type text not null,
+  payload jsonb not null default '{}'::jsonb,
+  status text not null default 'ok' check (status in ('ok','warning','error')),
+  created_at timestamptz not null default now()
+);
+
+create table if not exists public.scheduled_tasks_log (
+  id bigint generated always as identity primary key,
+  task_name text not null,
+  status text not null check (status in ('queued','running','success','failed')),
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  meta jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_user_profiles_created_at on public.user_profiles(created_at);
+create index if not exists idx_quiz_content_created_at on public.quiz_content(created_at);
+create index if not exists idx_quiz_content_status on public.quiz_content(status);
+create index if not exists idx_quiz_attempts_user_id on public.quiz_attempts(user_id);
+create index if not exists idx_quiz_attempts_created_at on public.quiz_attempts(created_at);
+create index if not exists idx_quiz_attempts_status on public.quiz_attempts(status);
+create index if not exists idx_user_events_user_id on public.user_events(user_id);
+create index if not exists idx_user_events_created_at on public.user_events(created_at);
+create index if not exists idx_user_events_status on public.user_events(status);
+create index if not exists idx_scheduled_tasks_log_created_at on public.scheduled_tasks_log(created_at);
+create index if not exists idx_scheduled_tasks_log_status on public.scheduled_tasks_log(status);
+
+alter table public.user_profiles enable row level security;
+alter table public.quiz_content enable row level security;
+alter table public.quiz_attempts enable row level security;
+alter table public.user_events enable row level security;
+alter table public.scheduled_tasks_log enable row level security;
+
+create policy if not exists user_profiles_owner_rw on public.user_profiles
+for all to authenticated
+using (id = auth.uid())
+with check (id = auth.uid());
+
+create policy if not exists user_profiles_admin_all on public.user_profiles
+for all to service_role
+using (true)
+with check (true);
+
+create policy if not exists quiz_content_owner_rw on public.quiz_content
+for all to authenticated
+using (created_by = auth.uid())
+with check (created_by = auth.uid());
+
+create policy if not exists quiz_content_admin_all on public.quiz_content
+for all to service_role
+using (true)
+with check (true);
+
+create policy if not exists quiz_attempts_owner_rw on public.quiz_attempts
+for all to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy if not exists quiz_attempts_admin_all on public.quiz_attempts
+for all to service_role
+using (true)
+with check (true);
+
+create policy if not exists user_events_owner_rw on public.user_events
+for all to authenticated
+using (user_id = auth.uid())
+with check (user_id = auth.uid());
+
+create policy if not exists user_events_admin_all on public.user_events
+for all to service_role
+using (true)
+with check (true);
+
+create policy if not exists scheduled_tasks_log_admin_all on public.scheduled_tasks_log
+for all to service_role
+using (true)
+with check (true);
+
+create or replace function public.rpc_dashboard_attempt_summary(p_from timestamptz default now() - interval '30 days')
+returns table(total_attempts bigint, completed_attempts bigint, avg_score numeric)
+language sql
+security definer
+set search_path = public
+as $$
+  select
+    count(*)::bigint as total_attempts,
+    count(*) filter (where status = 'completed')::bigint as completed_attempts,
+    coalesce(avg(score), 0)::numeric as avg_score
+  from public.quiz_attempts
+  where created_at >= p_from;
+$$;
+
+create or replace function public.rpc_cron_stale_attempts(p_older_than interval default interval '2 hours')
+returns table(attempt_id uuid, user_id uuid, started_at timestamptz)
+language sql
+security definer
+set search_path = public
+as $$
+  select id, user_id, started_at
+  from public.quiz_attempts
+  where status = 'started'
+    and started_at < now() - p_older_than;
+$$;

--- a/utils/supabase/client-with-anon-jwt.ts
+++ b/utils/supabase/client-with-anon-jwt.ts
@@ -4,6 +4,7 @@
  */
 
 import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "@/lib/supabase/types";
 
 export function createClientWithAnonJwt(token: string) {
 	const isDev = process.env.NODE_ENV === "development";
@@ -15,7 +16,7 @@ export function createClientWithAnonJwt(token: string) {
 		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
 		process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!;
 
-	return createBrowserClient(supabaseUrl, supabaseKey, {
+	return createBrowserClient<Database>(supabaseUrl, supabaseKey, {
 		global: {
 			headers: {
 				Authorization: `Bearer ${token}`,

--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,4 +1,5 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { Database } from "@/lib/supabase/types";
 
 export const createClient = () => {
 	const isDev = process.env.NODE_ENV === "development";
@@ -10,5 +11,5 @@ export const createClient = () => {
 		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
 		process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!;
 
-	return createBrowserClient(supabaseUrl, supabaseKey);
+	return createBrowserClient<Database>(supabaseUrl, supabaseKey);
 };


### PR DESCRIPTION
### Motivation
- Provide core database entities and indexes for profiles, quiz content, attempts, events and scheduled-task logs to support analytics and background jobs. 
- Secure user data by enabling Row Level Security (RLS) and adding owner read/write and service/admin policies. 
- Improve developer DX and safety by generating and using typed Supabase schema and centralizing Supabase error mapping in service code. 

### Description
- Added a new migration `supabase/migrations/07-core-entities-rls-and-rpc.sql` to create `user_profiles`, `quiz_content`, `quiz_attempts`, `user_events`, and `scheduled_tasks_log`, add indexes on common filters (`created_at`, `user_id`, status), enable RLS on these tables, add owner and `service_role` policies, and provide two RPCs `rpc_dashboard_attempt_summary` and `rpc_cron_stale_attempts` for dashboard aggregation and cron jobs. 
- Introduced a typed Supabase bridge in `lib/supabase/types.ts` that re-exports the generated `Database` type from `lib/database.types.ts` and helper types `TableRow`, `TableInsert`, and `TableUpdate`. 
- Added a centralized error mapper `lib/services/supabase-error.ts` that converts Supabase/PostgREST errors to a `ServiceError` and mapped common errors (e.g. `PGRST116` -> "Resource not found"). 
- Wired the browser Supabase clients to the typed `Database` generic in `utils/supabase/client.ts` and `utils/supabase/client-with-anon-jwt.ts`. 
- Updated service implementations in `lib/services/session.service.ts` and `lib/services/quiz.service.ts` to use the typed `TableRow`/`TableInsert`/`TableUpdate` types and use `mapSupabaseError` for consistent error messages. 

### Testing
- Ran linter with `pnpm -s lint` which completed successfully and reported existing repository warnings but no new errors introduced by this change. 
- Changes were committed and staged for PR after the lint run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd9225048832d9b0c7440b6daec96)