### PR TITLE
feat: harden server Supabase access, add role guards, rate limiting, and input validation

### DIFF
--- a/app/api/analytics/from-md/route.ts
+++ b/app/api/analytics/from-md/route.ts
@@ -1,43 +1,44 @@
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
 import fs from "node:fs/promises"
 import path from "node:path"
+import { z } from "zod"
+import { checkRateLimit } from "@/lib/api/rate-limit"
 
-type MdResponse = {
-  question_id: string
-  is_correct: boolean
-  kpi_category?: string
-  created_at?: string
-}
+const mdResponseSchema = z.object({
+  question_id: z.string().min(1),
+  is_correct: z.boolean(),
+  kpi_category: z.string().optional(),
+  created_at: z.string().optional(),
+})
 
-export async function GET() {
+const mdPayloadSchema = z.array(mdResponseSchema).min(1)
+
+export async function GET(request: NextRequest) {
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
+  const rate = checkRateLimit(`analytics-from-md:${ip}`)
+
+  if (!rate.allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
+  }
+
   try {
     const filePath = path.join(process.cwd(), "quiz_response.md")
     const raw = await fs.readFile(filePath, "utf8")
 
     const codeBlocks = Array.from(raw.matchAll(/```json\s*([\s\S]*?)\s*```/g))
     if (!codeBlocks.length) {
-      return NextResponse.json(
-        {
-          error: "No JSON code block found in quiz_response.md",
-          hint: "Add a ```json ... ``` block with an array of responses",
-          example: [
-            { question_id: "q1", is_correct: true, kpi_category: "SCAM_RECOGNITION" },
-            { question_id: "q2", is_correct: false, kpi_category: "PROTECTIVE_ACTIONS" },
-          ],
-        },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: "No JSON code block found in quiz_response.md" }, { status: 400 })
     }
 
     const jsonText = codeBlocks[0][1]
-    const data = JSON.parse(jsonText) as MdResponse[]
+    const parsed = JSON.parse(jsonText)
+    const data = mdPayloadSchema.parse(parsed)
 
-    // Compute wrong counts per question
     const wrongMap = new Map<string, { question_id: string; wrong_count: number; total_attempts: number }>()
     for (const r of data) {
       const q = wrongMap.get(r.question_id) || { question_id: r.question_id, wrong_count: 0, total_attempts: 0 }
       q.total_attempts += 1
-      if (r.is_correct === false) q.wrong_count += 1
+      if (!r.is_correct) q.wrong_count += 1
       wrongMap.set(r.question_id, q)
     }
 
@@ -53,7 +54,6 @@ export async function GET() {
       .sort((a, b) => (a.wrong_count || 0) - (b.wrong_count || 0))
       .slice(0, 10)
 
-    // Compute simple KPI averages per category
     const byCat = new Map<string, { correct: number; total: number }>()
     for (const r of data) {
       const key = r.kpi_category || "UNKNOWN"
@@ -77,4 +77,3 @@ export async function GET() {
     return NextResponse.json({ error: message }, { status: 500 })
   }
 }
-

--- a/app/api/analytics/overview/route.ts
+++ b/app/api/analytics/overview/route.ts
@@ -1,12 +1,23 @@
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
 import { getAnalyticsOverview } from "@/lib/actions/analytics"
+import { requireAdminOrSystem } from "@/lib/auth/guards"
+import { checkRateLimit } from "@/lib/api/rate-limit"
 
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown"
+  const rate = checkRateLimit(`analytics-overview:${ip}`)
+
+  if (!rate.allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 })
+  }
+
   try {
+    await requireAdminOrSystem()
     const data = await getAnalyticsOverview()
     return NextResponse.json(data, { status: 200 })
   } catch (e) {
     const message = e instanceof Error ? e.message : "Unknown error"
-    return NextResponse.json({ error: message }, { status: 500 })
+    const status = message === "Unauthorized" ? 401 : message === "Forbidden" ? 403 : 500
+    return NextResponse.json({ error: message }, { status })
   }
 }

--- a/lib/actions/quiz.ts
+++ b/lib/actions/quiz.ts
@@ -3,6 +3,17 @@
 
 import { createClient } from "@/utils/supabase/server";
 import { createServerClientWithToken } from "@/utils/supabase/server-with-token";
+import { z } from "zod";
+
+
+const quizSummarySchema = z.object({
+	sessionId: z.string().min(1),
+	totalQuestions: z.number().int().positive(),
+	correctAnswers: z.number().int().min(0),
+	deviceType: z.string().optional(),
+	anonymousUserId: z.string().optional(),
+	token: z.string().optional().nullable(),
+});
 
 export async function submitQuizSummaryAction(
 	prevState: unknown,
@@ -17,7 +28,16 @@ export async function submitQuizSummaryAction(
 		const anonymousUserId = rawData.anonymousUserId as string;
 		const token = (rawData.token as string)?.trim() || null;
 
-		const supabase = token
+		const payload = quizSummarySchema.parse({
+			sessionId,
+			totalQuestions,
+			correctAnswers,
+			deviceType,
+			anonymousUserId,
+			token,
+		});
+
+		const supabase = payload.token
 			? createServerClientWithToken(token)
 			: await createClient();
 

--- a/lib/api/rate-limit.ts
+++ b/lib/api/rate-limit.ts
@@ -1,0 +1,22 @@
+import "server-only";
+
+const windowMs = 60_000;
+const maxRequests = 60;
+const bucket = new Map<string, { count: number; resetAt: number }>();
+
+export function checkRateLimit(key: string) {
+  const now = Date.now();
+  const state = bucket.get(key);
+
+  if (!state || now > state.resetAt) {
+    bucket.set(key, { count: 1, resetAt: now + windowMs });
+    return { allowed: true, remaining: maxRequests - 1, resetAt: now + windowMs };
+  }
+
+  if (state.count >= maxRequests) {
+    return { allowed: false, remaining: 0, resetAt: state.resetAt };
+  }
+
+  state.count += 1;
+  return { allowed: true, remaining: maxRequests - state.count, resetAt: state.resetAt };
+}

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,0 +1,31 @@
+import "server-only";
+
+import { createClient } from "@/utils/supabase/server";
+
+export type AppRole = "user" | "admin" | "system";
+
+function getRoleFromUser(user: { app_metadata?: Record<string, unknown> | null; user_metadata?: Record<string, unknown> | null }): AppRole {
+  const appRole = user.app_metadata?.role;
+  const userRole = user.user_metadata?.role;
+  const candidate = (typeof appRole === "string" ? appRole : typeof userRole === "string" ? userRole : "user").toLowerCase();
+
+  if (candidate === "admin") return "admin";
+  if (candidate === "system") return "system";
+  return "user";
+}
+
+export async function requireRole(allowed: AppRole[]) {
+  const supabase = await createClient();
+  const { data, error } = await supabase.auth.getUser();
+
+  if (error || !data.user) throw new Error("Unauthorized");
+
+  const role = getRoleFromUser(data.user);
+  if (!allowed.includes(role)) throw new Error("Forbidden");
+
+  return { user: data.user, role };
+}
+
+export async function requireAdminOrSystem() {
+  return requireRole(["admin", "system"]);
+}

--- a/utils/supabase/admin.ts
+++ b/utils/supabase/admin.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createServerClient } from "@supabase/ssr"
 
 // Server-only Supabase client using the Service Role key.

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,3 +1,4 @@
+import "server-only";
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { cookies } from "next/headers";
 


### PR DESCRIPTION
### Motivation
- Ensure Supabase service-role and server clients are only used from server-only paths to prevent leaking privileged keys into client bundles.
- Add concise server-side role checks so privileged analytics and management endpoints require `admin`/`system` roles.
- Prevent malformed or abusive requests by validating mutation payloads and adding simple rate-limiting for public endpoints.

### Description
- Marked server Supabase helpers as server-only by adding `import "server-only";` to `utils/supabase/server.ts` and `utils/supabase/admin.ts` and kept the admin client reading `SECRET_KEY` server-side only.
- Added role guard utilities in `lib/auth/guards.ts` with `requireRole()` and `requireAdminOrSystem()` to assert `user|admin|system` roles on server actions.
- Implemented a lightweight in-memory rate limiter in `lib/api/rate-limit.ts` and applied per-IP checks to `app/api/analytics/overview/route.ts` and `app/api/analytics/from-md/route.ts` returning `429` when exceeded.
- Added strict input validation with `zod` for the markdown analytics endpoint (`mdPayloadSchema`) and for the quiz summary server action (`quizSummarySchema`) in `lib/actions/quiz.ts`, and normalized error status mapping (`401/403/500`) in the analytics overview route.

### Testing
- Ran `pnpm lint`, which completed successfully with only pre-existing warnings and no new ESLint errors.
- No new automated unit tests were added in this change; existing test suite was not modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ddc12eacc832d82c693d09b898b2b)